### PR TITLE
Updated README.md ; Added alternate link to download data for mnist

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Download the following files:
 * `t10k-images-idx3-ubyt.gz`
 * `t10k-labels-idx1-ubyte.gz`
 
+[OR]
+
+If it has issues, download directly from Github:
+
+* `$ wget https://raw.githubusercontent.com/fgnt/mnist/master/train-images-idx3-ubyte.gz`
+* `$ wget https://raw.githubusercontent.com/fgnt/mnist/master/train-labels-idx1-ubyte.gz`
+* `$ wget https://raw.githubusercontent.com/fgnt/mnist/master/t10k-images-idx3-ubyte.gz`
+* `$ wget https://raw.githubusercontent.com/fgnt/mnist/master/t10k-labels-idx1-ubyte.gz`
+
 Once downloaded, gunzip them to the `data/mnist/` directory. You need the
 Python package idx2numpy to use this version of the MNIST dataset.
 


### PR DESCRIPTION
Hi Magnus,
I was installing the dataset of MNIST by following your README.md, but I faced the issue of website showing Forbidden Access when downloading the datasets for training and test [Attached the screenshot]. So, I am creating this pull request to add an alternative link to download the dataset which I used.

![Screenshot 2024-07-27 220648](https://github.com/user-attachments/assets/804a5a0d-d4a2-48d6-b580-1fe9e1d5e6c8)
